### PR TITLE
Repair effective_sizes/dm6_50.txt

### DIFF
--- a/epic/scripts/effective_sizes/dm6_50.txt
+++ b/epic/scripts/effective_sizes/dm6_50.txt
@@ -1,4 +1,4 @@
 File analyzed:  trimmed_fasta/dm6.trimmed.fa
 Genome length:  137567484
-Number unique 50-mers:  19088831
-Effective genome size:  0.138759759537
+Number unique 50-mers:  120949316
+Effective genome size:  0.8791998841819336


### PR DESCRIPTION
For unclear reasons, the effective size estimate for dm6/50 is incorrect (current estimate of effective fraction is 0.139, actual is 0.879). It does not represent the output of the genome.snakefile run for that combination of parameters, even bearing in mind version changes since the original run which cause minor differences for the other outputs. This modification replaces the dm6_50.txt file with the current output of the pipeline for this file.