### PR TITLE
Stop coveralls from being picked up as a dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,11 +15,8 @@ from epic.version import __version__
 
 install_requires = ["scipy", "pandas>=0.23.0", "numpy", "natsort", "joblib", "pyfaidx", "typing", "cython"]
 
-try:
-    os.getenv("TRAVIS")
+if os.getenv("TRAVIS"):
     install_requires.append("coveralls")
-except:
-    pass
 
 if sys.version_info[0] == 2:
     install_requires.append("functools32")


### PR DESCRIPTION
* `os.getenv("TRAVIS")` never raises any errors, defaults to 'None'
* but 'None' is false-ish, can be used in an `if` statement